### PR TITLE
Guardian登録の仕上げ: 招待リンク/登録完了導線/フォームUI・バリデーション整備

### DIFF
--- a/src/app/Http/Controllers/Admin/StudentInviteController.php
+++ b/src/app/Http/Controllers/Admin/StudentInviteController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Student;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\GuardianInviteMail;
+use Illuminate\Http\Request;
+
+class StudentInviteController extends Controller
+{
+    public function send(Student $student){
+
+        // 既に保護者登録済みなら再送しない
+    if ($student->guardian_registered_at) {
+        return back()->with('status','この学生は既に保護者登録済みです。');
+
+    }
+    // トークンが無ければ発行
+    if (empty($student->guardian_registration_token)) {
+        [$token] = \App\Models\Student::issueGuardianToken(30);
+        $student->guardian_registration_token = $token;
+        $student->save();
+    }
+    Mail::to($student->email)->send(new GuardianInviteMail($student));
+
+    return back()->with('status','招待メールを再送しました。');
+
+    }
+    
+}

--- a/src/app/Mail/GuardianInviteMail.php
+++ b/src/app/Mail/GuardianInviteMail.php
@@ -8,8 +8,9 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class GuardianInviteMail extends Mailable
+class GuardianInviteMail extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 

--- a/src/app/Models/Student.php
+++ b/src/app/Models/Student.php
@@ -9,6 +9,11 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
 
+
+use Illuminate\Support\Facades\Mail;
+use App\Mail\GuardianInviteMail;
+use Illuminate\Support\Facades\Schema;
+
 class Student extends Authenticatable implements MustVerifyEmail
 {
     use HasApiTokens,HasFactory,Notifiable;
@@ -29,6 +34,9 @@ class Student extends Authenticatable implements MustVerifyEmail
                 [$token,$expiresAt] = self::issueGuardianToken(30);
                 $student->guardian_registration_token = $token;
             }
+        });
+        static::created(function (Student $student) {
+            Mail::to($student->email)->queue(new GuardianInviteMail($student));
         });
     }
     public static function issueGuardianToken(int $days = 30): array

--- a/src/database/migrations/2025_08_30_142115_create_jobs_table.php
+++ b/src/database/migrations/2025_08_30_142115_create_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/src/resources/views/admin/students/show.blade.php
+++ b/src/resources/views/admin/students/show.blade.php
@@ -14,7 +14,11 @@
   @if(session('status'))
     <div class="alert alert-success">{{ session('status') }}</div>
   @endif
+  @if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+  @endif
 
+  {{-- 学生情報カード --}}
   <div class="card">
     <div class="card-body">
       <dl class="row">
@@ -42,6 +46,48 @@
     </div>
   </div>
 
+  {{-- ★ 保護者登録カード（ここに移動） --}}
+  <div class="card mt-3">
+    <div class="card-header">保護者登録</div>
+    <div class="card-body">
+      @if($student->guardian_registered_at)
+        <p class="mb-2">
+          状態: <span class="badge bg-success">登録済み</span>
+        </p>
+        <dl class="row">
+          <dt class="col-sm-3">登録日時</dt>
+          <dd class="col-sm-9">{{ $student->guardian_registered_at?->format('Y-m-d H:i') }}</dd>
+        </dl>
+      @else
+        <p class="mb-2">
+          状態: <span class="badge bg-warning text-dark">未登録</span>
+        </p>
+
+        @if($student->guardian_registration_token)
+          <p class="small text-muted mb-1">招待URL</p>
+          <div class="input-group mb-3">
+            <input type="text" class="form-control" readonly
+                   value="{{ route('guardian.register.token.show', ['token' => $student->guardian_registration_token]) }}">
+            <button class="btn btn-outline-secondary" type="button"
+                    onclick="navigator.clipboard.writeText(this.previousElementSibling.value)">
+              コピー
+            </button>
+          </div>
+        @else
+          <p class="text-muted">現在トークンがありません（再招待すると自動発行されます）。</p>
+        @endif
+
+        <form method="POST" action="{{ route('admin.students.invite', $student) }}" class="d-inline">
+          @csrf
+          <button type="submit" class="btn btn-primary">
+            保護者招待メールを再送
+          </button>
+        </form>
+      @endif
+    </div>
+  </div>
+
+  {{-- 戻る・編集・削除ボタン群 --}}
   <div class="mt-3 d-flex justify-content-between">
     <a href="{{ route('admin.students.index') }}" class="btn btn-outline-secondary">一覧に戻る</a>
 

--- a/src/resources/views/guardian/auth/register-complete.blade.php
+++ b/src/resources/views/guardian/auth/register-complete.blade.php
@@ -1,20 +1,20 @@
-+<!doctype html>
-+<html lang="ja">
-+<head>
-+  <meta charset="utf-8">
-+  <title>保護者登録 完了</title>
-+  <meta name="viewport" content="width=device-width, initial-scale=1">
-+</head>
-+<body>
-+  <h1>保護者登録が完了しました</h1>
-+  <p>登録が正常に完了しました。引き続きシステムをご利用ください。</p>
-+
-+  <p style="margin-top:16px;">
-+    @if (Route::has('guardian.login'))
-+      <a href="{{ route('guardian.login') }}">保護者ログインへ</a>
-+    @else
-+      <a href="{{ url('/guardian/login') }}">保護者ログインへ</a>
-+    @endif
-+  </p>
-+</body>
-+</html>
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>保護者登録 完了</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <h1>保護者登録が完了しました</h1>
+  <p>登録が正常に完了しました。引き続きシステムをご利用ください。</p>
+
+  <p style="margin-top:16px;">
+    @if (Route::has('guardian.login'))
+      <a href="{{ route('guardian.login') }}">保護者ログインへ</a>
+    @else
+      <a href="{{ url('/guardian/login') }}">保護者ログインへ</a>
+    @endif
+  </p>
+</body>
+</html>

--- a/src/resources/views/guardian/auth/register-with-token.blade.php
+++ b/src/resources/views/guardian/auth/register-with-token.blade.php
@@ -12,11 +12,11 @@
   <p>対象の学生：{{ $student->name }}（学籍番号：{{ $student->student_number }}）</p>
 
   {{-- 全体エラー（必要に応じて） --}}
-+  @if ($errors->any())
-+    <div style="color:#a00; margin-bottom:12px;">
-+      入力内容に誤りがあります。各項目のエラーをご確認ください。
-+    </div>
-+  @endif
+  @if ($errors->any())
+    <div style="color:#a00; margin-bottom:12px;">
+      入力内容に誤りがあります。各項目のエラーをご確認ください。
+    </div>
+  @endif
 
   {{-- 完了メッセージ --}}
   @if (session('status') === 'registered')
@@ -29,44 +29,44 @@
 
     <div style="margin-bottom:8px;">
       <label for="name">お名前</label><br>
-+      <input id="name" type="text" name="name" value="{{ old('name') }}" required autofocus autocomplete="name">
-+      @error('name')
-+        <div style="color:#a00; font-size:12px;">{{ $message }}</div>
-+      @enderror
+      <input id="name" type="text" name="name" value="{{ old('name') }}" required autofocus autocomplete="name">
+      @error('name')
+        <div style="color:#a00; font-size:12px;">{{ $message }}</div>
+      @enderror
     </div>
 
     <div style="margin-bottom:8px;">
       <label for="relationship">続柄</label><br>
-+      <select id="relationship" name="relationship" required>
-+        <option value="" disabled {{ old('relationship') ? '' : 'selected' }}>選択してください（父 / 母 / 祖父 / 祖母 / その他）</option>
-+        @foreach (['父','母','祖父','祖母','その他'] as $opt)
-+          <option value="{{ $opt }}" {{ old('relationship') === $opt ? 'selected' : '' }}>{{ $opt }}</option>
-+        @endforeach
-+      </select>
-+      @error('relationship')
-+        <div style="color:#a00; font-size:12px;">{{ $message }}</div>
-+      @enderror
+      <select id="relationship" name="relationship" required>
+        <option value="" disabled {{ old('relationship') ? '' : 'selected' }}>選択してください（父 / 母 / 祖父 / 祖母 / その他）</option>
+        @foreach (['父','母','祖父','祖母','その他'] as $opt)
+          <option value="{{ $opt }}" {{ old('relationship') === $opt ? 'selected' : '' }}>{{ $opt }}</option>
+        @endforeach
+      </select>
+      @error('relationship')
+        <div style="color:#a00; font-size:12px;">{{ $message }}</div>
+      @enderror
     </div>
 
     <div style="margin-bottom:8px;">
       <label for="email">メールアドレス</label><br>
-+      <input id="email" type="email" name="email" value="{{ old('email') }}" required autocomplete="email">
-+      @error('email')
-+        <div style="color:#a00; font-size:12px;">{{ $message }}</div>
-+      @enderror
+      <input id="email" type="email" name="email" value="{{ old('email') }}" required autocomplete="email">
+      @error('email')
+        <div style="color:#a00; font-size:12px;">{{ $message }}</div>
+      @enderror
     </div>
 
     <div style="margin-bottom:8px;">
       <label for="password">パスワード</label><br>
-+      <input id="password" type="password" name="password" required autocomplete="new-password">
-+      @error('password')
-+        <div style="color:#a00; font-size:12px;">{{ $message }}</div>
-+      @enderror
+      <input id="password" type="password" name="password" required autocomplete="new-password">
+      @error('password')
+        <div style="color:#a00; font-size:12px;">{{ $message }}</div>
+      @enderror
     </div>
 
     <div style="margin-bottom:12px;">
       <label for="password_confirmation">パスワード（確認）</label><br>
-+      <input id="password_confirmation" type="password" name="password_confirmation" required autocomplete="new-password">
+      <input id="password_confirmation" type="password" name="password_confirmation" required autocomplete="new-password">
     </div>
 
     <button type="submit">登録する</button>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Student;
 use App\Http\Controllers\Guardian;
 use App\Http\Controllers\Teacher;
 use App\Http\Controllers\Guardian\RegisterWithTokenController;
+use App\Http\Controllers\Admin\StudentInviteController;
 
 /*
 |--------------------------------------------------------------------------
@@ -34,7 +35,7 @@ Route::group(['prefix' => 'guardian','as' => 'guardian.', 'middleware' => 'auth:
     Route::get('home',[Guardian\HomeController::class,'index'])->name('home');
 });
 // トークン付き保護者登録ルートを追加(ログイン不要)
-Route::prefix('guardians')->name('guardian.')->middleware('throttle:30,1')->group(function(){
+Route::prefix('guardians')->name('guardian.')->middleware(['guest:guardian','throttle:30,1'])->group(function(){
     Route::get('register/complete',[RegisterWithTokenController::class,'complete'])
         ->name('register.complete');
 
@@ -55,6 +56,10 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => 'auth:admin
 
     Route::resource('students',Admin\StudentController::class)->only(['index','show','edit','update','destroy']);
     Route::resource('teachers',Admin\TeacherController::class);
+
+    // 学生に招待メールを再送(POST)
+    Route::post('students/{student}/invite',[Admin\StudentInviteController::class,'send'])
+        ->name('students.invite');
 });
 
 // 教員ルート


### PR DESCRIPTION
- guardians 招待URL発行とメール文面を調整
- 続柄をセレクト必須化、完了画面にログイン導線
- ルート: guest:guardian / token制約
- RegisterWithToken のFeature/UIテスト整備
- （必要に応じて）queue用 jobs テーブル追加